### PR TITLE
Fix service worker update flow

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -27,6 +27,13 @@ self.addEventListener("activate", event => {
   self.clients.claim();                  // control pages without reload
 });
 
+/* ----------  MESSAGE  ---------- */
+self.addEventListener("message", event => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
+});
+
 /* ----------  FETCH  ---------- */
 self.addEventListener("fetch", event => {
   const { request } = event;


### PR DESCRIPTION
## Summary
- respond to `SKIP_WAITING` message in service worker so updates activate immediately

## Testing
- `node -e "require('fs').readFileSync('service-worker.js')"`